### PR TITLE
Rework on boot documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,22 +98,19 @@ http:
         certResolver: le
 ```
 
-# Crontab
+# Start on boot
 
-Traefik does not start by default in FreeBSD. We use crontab to auto start our Traefik script
+To start Traefik on boot, in addition to setting `traefik_enable=YES`, we need to specify which configuration file Traefik needs to load on boot. This is done by setting `traefik_conf=""` in `/etc/rc.conf`, in our example this would be `traefik_conf="/usr/local/etc/traefik.yml"`
 
-```
-crontab -e
-```
-
-Paste the following:
-
-```
-@reboot /usr/local/bin/traefik --configFile=/usr/local/etc/traefik.yml
-```
-
-Finally, hit reboot to test
+Hit reboot to test
 
 ```
 reboot
+```
+
+Finally, validate that Traefik is running
+
+```console
+root@proxy:~ # service traefik status
+traefik is running as pid 27019.
 ```


### PR DESCRIPTION
According to your documentation, the Traefik port does not support starting on boot, this may have been true at the time of writing. But currently this is supported by enabling Traefik in `rc.conf` and specifying the config file with `traefik_conf=""`.

This pull request aims to rework the relevant section to reflect the current best way to configure Traefik to start on FreeBSD.

Below you will find some information showing the new documentation applied on a system:
```
root@proxy:~ # cat /etc/rc.conf | grep traefik
traefik_enable="YES"
traefik_conf="/usr/local/etc/traefik.yml"
root@proxy:~ # service traefik status
traefik is running as pid 27019.
root@proxy:~ # cat /etc/os-release
NAME=FreeBSD
VERSION="13.2-RELEASE"
VERSION_ID="13.2"
ID=freebsd
ANSI_COLOR="0;31"
PRETTY_NAME="FreeBSD 13.2-RELEASE"
CPE_NAME="cpe:/o:freebsd:freebsd:13.2"
HOME_URL="https://FreeBSD.org/"
BUG_REPORT_URL="https://bugs.FreeBSD.org/"
root@proxy:~ # pkg info traefik
traefik-2.10.1
Name           : traefik
Version        : 2.10.1
Installed on   : Sun Jun 18 22:31:04 2023 CEST
Origin         : net/traefik
Architecture   : FreeBSD:13:amd64
Prefix         : /usr/local
Categories     : net
Licenses       : MIT
Maintainer     : riggs@FreeBSD.org
WWW            : https://traefik.io/
Comment        : High availability reverse proxy and load balancer
Annotations    :
	FreeBSD_version: 1301000
	cpe            : cpe:2.3:a:traefik:traefik:2.10.1:::::freebsd13:x64
	repo_type      : binary
	repository     : FreeBSD
Flat size      : 128MiB
Description    :
Traefik (pronounced like traffic) is a modern HTTP reverse proxy and load
balancer made to deploy microservices with ease. It supports several backends
(Docker, Swarm mode, Kubernetes, Marathon, Consul, Etcd, Rancher, Amazon ECS,
and a lot more) to manage its configuration automatically and dynamically.

WWW: https://traefik.io/
```